### PR TITLE
#107 Adding floodRate key to main.properties config

### DIFF
--- a/src/main/java/net/vortexdata/tsqpf/configs/ConfigMain.java
+++ b/src/main/java/net/vortexdata/tsqpf/configs/ConfigMain.java
@@ -57,6 +57,7 @@ public class ConfigMain extends Config {
         setDefaultValue("enableHeartbeat", "false", CheckType.BOOLEAN);
         setDefaultValue("acceptEula", "false", CheckType.BOOLEAN);
         setDefaultValue("enableExceptionReporting", "true", CheckType.BOOLEAN);
+        setDefaultValue("floodRate", "default", CheckType.STRING);
     }
 
 }

--- a/src/main/java/net/vortexdata/tsqpf/framework/FrameworkContainer.java
+++ b/src/main/java/net/vortexdata/tsqpf/framework/FrameworkContainer.java
@@ -171,6 +171,16 @@ public class FrameworkContainer {
         localTs3config.setHost(getConfig("configs//main.properties").getProperty("serverAddress"));
         frameworkLogger.printDebug("Server address assigned.");
 
+        String cfloodRate = getConfig(new ConfigMain(getFrameworkLogger()).getPath()).getProperty("floodRate");
+        if (cfloodRate.equalsIgnoreCase("UNLIMITED")) {
+            localTs3config.setFloodRate(TS3Query.FloodRate.UNLIMITED);
+            frameworkLogger.printDebug("Set flood rate to unlimited.");
+        } else if (cfloodRate.equalsIgnoreCase("DEFAULT")) {
+            frameworkLogger.printDebug("Set flood rate to default.");
+        } else {
+            frameworkLogger.printWarn("Config value for key floodRate could not be parsed, falling back to default.");
+        }
+
         frameworkLogger.printDebug("Trying to assign reconnect strategy...");
         String reconnectStrategy = getConfig(new ConfigMain(getFrameworkLogger()).getPath()).getProperty("reconnectStrategy");
         if (reconnectStrategy.equalsIgnoreCase("exponentialBackoff") || reconnectStrategy.equalsIgnoreCase("") || reconnectStrategy.isEmpty()) {


### PR DESCRIPTION
With this pull request, a new config key is added to main.properties, allowing the user to set flood rate to unlimited or default. Changing flood rate to unlimited may help to improve response time to chat commands.

Resolves: #107